### PR TITLE
Two Coin Pool with peggie and non-peggie, Raiust Pool

### DIFF
--- a/RAIUST_POOL_README.md
+++ b/RAIUST_POOL_README.md
@@ -1,0 +1,109 @@
+# Adapting Curve Base Pool for RAI
+
+This file provides documentation for the pull request to Adapt Curve V1 Contracts so a non-peggie (such as RAI) and a peggie (such as UST) can be swapped as described at [gitcoin](https://gitcoin.co/issue/reflexer-labs/curve-contract/6/100027296). In order to optimize, the coin in the pool should be with 18 decimals. 
+
+## Licence
+
+All changes are made under the (c) Curve.Fi, 2020 [licence](LICENSE)
+
+## Description of Modifications
+
+Main modification:
+
+The RAIUST pool created here is built from the [template code](https://etherscan.io/address/0x55A8a39bc9694714E2874c1ce77aa1E599461E18#code) with adaptions to handle RAIs moving redemption
+price. UST is the peggie coin used in this pool, RAI is the non-peggie coin used in this pool. The price of UST is stable, but the redmeption price of RAI is moving. It is usually necessary to get the latest redemption price snap to calculate the coin's balance and LP Token amount when depositing or withdrawing liquidity. I get the inspiration of fetching RAI's redemption price and redemption price adaption implementaion from the [RAI Metapool code](https://github.com/reflexer-labs/curve-contract/tree/master/contracts/pools/rai) and last [gitcoin project](https://gitcoin.co/issue/reflexer-labs/curve-contract/1/100026434).
+
+Other modifications: 
+1) [template code](https://etherscan.io/address/0x55A8a39bc9694714E2874c1ce77aa1E599461E18#code) has been optimized to support only ERC20 coin. I refer to the use of function "raw_call" in [SwapTemplateBase.vy](https://github.com/reflexer-labs/curve-contract/tree/master/contracts/pools-templates/base/SwapTemplateBase.vy) to make the contract support more coins; 
+2) [template code](https://etherscan.io/address/0x55A8a39bc9694714E2874c1ce77aa1E599461E18#code) provide LP Token balance by self, it cannot specify LP Token Address. I refer to the use of "CurveToken" in [SwapTemplateBase.vy](https://github.com/reflexer-labs/curve-contract/tree/master/contracts/pools-templates/base/SwapTemplateBase.vy) to support outer LP Token.
+3) Added some codes to make the contract satisfy brownie test demand.
+
+
+## Contracts
+
+To view the changes made for RAIUST from vanilla curve [contracts/pools/raiust/StableSwapRaiust.vy](contracts/pools/raiust/StableSwapRaiust.vy) should be compared to [template code](https://etherscan.io/address/0x55A8a39bc9694714E2874c1ce77aa1E599461E18#code).
+
+[pooldata.json](contracts/pools/raiust/pooldata.json): Filled in available constants, after deployments the 0x0 addresses should be replaced.
+
+[README.md](contracts/pools/raiust/README.md): Introdue RAIUST pool. Deployment addresses should be added to this later.
+
+[StableSwapRaiust.vy](contracts/pools/raiust/StableSwapRaiust.vy): This contains the core adaptions which make it possible swap between a non-peggie (such as RAI) and a peggie (such as UST) in curve. In order to optimize, the coin in the pool should be with 18 decimals. Descriptions of key changes:
+
+#### State Variables:
+Added an interface for the RAI redemption price snapshot [contract](https://github.com/reflexer-labs/geb-redemption-price-snap/blob/master/src/RedemptionPriceSnap.sol) which exposes the auto generated snappedRedemptionPrice getter method. 
+Added CurveToken interface which can be used to specify the LP Token address.
+Added some constants, such as RATES for peggie coin(such as UST) and REDMPTION_PRICE_SCALE for non-peggie coin(such as RAI).
+Deleted the lp token state variables in self, such as balanceOf, allowance, totalSupply.
+
+#### __init__():
+Added an additional input argument so the redemption_price_snap address can be stored.
+
+#### _get_scaled_redemption_price(): 
+New view method which is used to read the redemption price from the snapshot and scale it to the precision used in this stableswap pool. This is called from many other view methods so a read only method simplifies things, avoids surprise slippage and min_dy errors, saves gas in trade txs and removes need for special treatment in curve web UI.
+
+#### _xp():
+New view internal method. This weights the quantity of tokens by their value with element-wise multiplication. Previously it was mainly used to allow pools of coins with differing levels of precision set in RATES. This modification extends the mechanism so the quantities are multiplied by a array of [self._get_scaled_redemption_price(), RATES] which gives a result that works for the D component of curves StableSwap calculation.
+
+#### _xp_mem():
+New view internal method. Memento or pure version of _xp(). Same as above but with balances passed in.
+
+#### _get_D():
+Adpate the internal method. Make the internal method name start from "_". And whenever invoking the method, _xp not the balance is passed in. 
+
+#### _get_D_mem():
+New view internal method. Adapted to also pass redemption price.
+
+#### calc_token_amount():
+The change in supply of LP tokens after a deposit or withdrawal is dependent upon the redemption price as it effectively changes ratio of the two assets. So now this also passes in the redemption price to the D calculation.
+
+#### add_liquidity():
+Amount of LP tokens received by depositing coins into the pool. It also depends on redempton price.
+
+#### _get_dy(), _get_y():
+Calculate the current output dy given input dx, or calculate the current output y given input x. Also now dependent on redemption price. 
+
+#### exchange():
+Perform an exchange between two coins given the amount dx of coin being exchanged. Also now dependent on redemption price. 
+
+#### remove_liquidity_imbalance():
+Withdraw coins from the pool in an imbalanced amount. Also now dependent on redemption price. 
+
+#### _get_y_D():
+Calculate the current output y given input two coins' xp and D. Also now dependent on redemption price. 
+
+#### _calc_withdraw_one_coin(), calc_withdraw_one_coin(), remove_liquidity_one_coin():
+Withdraw a single coin from the pool. Also now dependent on redemption price. 
+
+## Brownie Test
+### Test Code
+
+The new RAIUST pool is covered by all preexisting common tests, this works because the [mock redemption price snapshot contract](contracts/testing/RedemptionPriceSnapMock.sol) is initialised to give a redemption price of 1.0. Additional tests focussing on moving the redemption price and exercising relevant areas have been added at [tests/pools/raiust](tests/pools/raiust). RAIUST pool tests can be run with "brownie test --pool raiust" after following Curve's setup instructions. Reflexer-labs has given [test code for RAI meta pool](https://github.com/reflexer-labs/curve-contract/tree/master/tests/pools/rai/). Although the test code is for meta pool, some of the test codes are still quite useful for base pool test. My test codes refer to both [test code for RAI meta pool](https://github.com/reflexer-labs/curve-contract/tree/master/tests/pools/rai/) and [test code template](https://github.com/reflexer-labs/curve-contract/tree/master/tests/pools/common), and make some modifications of them.   
+
+Descriptions by file of the new tests and their coverage:
+
+[test_add_liquidity_initial_moving_rp_raiust.py](tests/pools/raiust/unitary/test_add_liquidity_initial_moving_rp_raiust.py): Does not use the standard fixture to add the initial liquidity and instead adds it after modifying the redemption price. Checks
+that the correct amount of pool tokens are minted and awarded and that the min_amount of LP tokens gained takes into account the redemption price. Also makes sure the modified redemption price doesn't allow depositing of zero on one side of the first deposit.
+
+[test_add_liquidity_moving_rp_raiust.py](tests/pools/raiust/unitary/test_add_liquidity_moving_rp_raiust.py): Initial liquidity is already added by the add_initial_liquidity fixture. This test modifies the redemption price before adding additional liquidity and ensures the depositor is awarded a fair quantity of pool tokens. It tests all combinations of higher and lower RP and single sided deposits on each side.
+
+[test_exchange_moving_rp_raiust.py](tests/pools/raiust/unitary/test_exchange_moving_rp_raiust.py): Swaps RAI for UST at lower, equal and higher redemption prices to the initial value. Asserts the trade is successful and that Bob loses the RAI and gains the correct quantity of UST. It then swaps in the reverse direction and makes sure the result is correct that way too.
+
+[test_remove_liquidity_imbalance_moving_rp_raiust.py](tests/pools/rai/unitary/test_remove_liquidity_imbalance_moving_rp_raiust.py): This test is run with all permutations of the side removing half the liquidity and causing an imbalance by lowering or raising the redemption price. It makes sure the correct amount is removed from the pool and added to the caller, and
+then that the correct amount of pool tokens are deducted from the user and burnt. The next tests make sure attempts to withdraw too much liquidity for the specified max amount of pool tokens to burn fail appropriately with a moving redemption price.
+
+[test_remove_liquidity_moving_rp_raiust.py](tests/pools/raiust/unitary/test_remove_liquidity_moving_rp_raiust.py): Tests removing equal portions of liquidity from both sides makes sure the results are independent of the moving redemption price.
+
+[test_rp_caching_raiust.py](tests/pools/raiust/unitary/test_rp_caching_raiust.py): Ensures the redemption price mock contract performs as expected.
+
+[test_rp_moving_raiust.py](tests/pools/raiust/integration/test_redemption_rate_handling_raiust.py): This is a stateful test which performs various permutations of actions including modifying the redemption price. It ensures the integrity of the base pool by making sure the base pools virtual price only increases.
+
+[deployments.py](tests/fixtures/deployments.py): The redemption_price_snap has been added to the file in the forked [reflexer-labs/curve-contract master branch](https://github.com/reflexer-labs/curve-contract). The new pool name "raiust" should be added to pool_data in fixture redemption_price_snap.
+
+### Test Instruction
+The test has been done locally. Test environment includes: platform win32 -- Python 3.8.1 eth-brownie-1.17.2 Vyper-0.2.12 Ganache-cli-6.12.2 VisualCode-2021. The contract has passed all default [common integration test](tests/pools/common/integration/) and [common unitary test](tests/pools/common/unitary/). Meanwhile the [specific integration test](tests/pools/raiust/integration/) and [specific unitary test](tests/pools/raiust/unitary/) including the moving redemption price has also gone through. 
+
+To run tests:
+
+```bash
+brownie test tests/ --pool raiust
+```

--- a/contracts/pools/raiust/README.md
+++ b/contracts/pools/raiust/README.md
@@ -1,0 +1,14 @@
+# curve-contract/contracts/pools/raiust
+
+[Curve raiust-pool](): Two coins pool which includes RAI(non-peggie) and UST(peggie) with 18 decimals. 
+
+## Contracts
+
+* [`StableSwapRaiust`](StableSwapRaiust.vy): Curve stablecoin AMM contract to swap between a non-peggie(RAI) and a peggie(UST), without lending. 
+
+## Stablecoins
+
+Curve raiust-pool supports swaps between the following stablecoins:
+
+* `RAI`: [0x03ab458634910AaD20eF5f1C8ee96F1D6ac54919](https://etherscan.io/address/0x03ab458634910AaD20eF5f1C8ee96F1D6ac54919)
+* `UST`: [0xa47c8bf37f92aBed4A126BDA807A7b7498661acD](https://etherscan.io/address/0xa47c8bf37f92aBed4A126BDA807A7b7498661acD)

--- a/contracts/pools/raiust/StableSwapRaiust.vy
+++ b/contracts/pools/raiust/StableSwapRaiust.vy
@@ -1,0 +1,966 @@
+# @version 0.2.12
+"""
+@title StableSwapRAIUST
+@author Curve.Fi
+@license Copyright (c) Curve.Fi, 2020-2021 - all rights reserved
+@notice 2 coin pool implementation with a non-peggie and a peggie, without lending 
+@dev Swaps between a non-peggie(RAI) and a peggie(UST) with 18 decimals.  
+"""
+
+from vyper.interfaces import ERC20
+
+interface CurveToken:
+    def totalSupply() -> uint256: view
+    def mint(_to: address, _value: uint256) -> bool: nonpayable
+    def burnFrom(_to: address, _value: uint256) -> bool: nonpayable
+
+### redemption price snap interface 
+interface RedemptionPriceSnap:
+    def snappedRedemptionPrice() -> uint256: view
+
+
+event Transfer:
+    sender: indexed(address)
+    receiver: indexed(address)
+    value: uint256
+
+event Approval:
+    owner: indexed(address)
+    spender: indexed(address)
+    value: uint256
+
+event TokenExchange:
+    buyer: indexed(address)
+    sold_id: int128
+    tokens_sold: uint256
+    bought_id: int128
+    tokens_bought: uint256
+
+event AddLiquidity:
+    provider: indexed(address)
+    token_amounts: uint256[N_COINS]
+    fees: uint256[N_COINS]
+    invariant: uint256
+    token_supply: uint256
+
+event RemoveLiquidity:
+    provider: indexed(address)
+    token_amounts: uint256[N_COINS]
+    fees: uint256[N_COINS]
+    token_supply: uint256
+
+event RemoveLiquidityOne:
+    provider: indexed(address)
+    token_amount: uint256
+    coin_amount: uint256
+    token_supply: uint256
+
+event RemoveLiquidityImbalance:
+    provider: indexed(address)
+    token_amounts: uint256[N_COINS]
+    fees: uint256[N_COINS]
+    invariant: uint256
+    token_supply: uint256
+
+event RampA:
+    old_A: uint256
+    new_A: uint256
+    initial_time: uint256
+    future_time: uint256
+
+event StopRampA:
+    A: uint256
+    t: uint256
+
+event CommitNewAdmin:
+    deadline: indexed(uint256)
+    admin: indexed(address)
+
+event NewAdmin:
+    admin: indexed(address)
+
+event CommitNewFee:
+    deadline: indexed(uint256)
+    fee: uint256
+    admin_fee: uint256
+
+event NewFee:
+    fee: uint256
+    admin_fee: uint256
+
+
+N_COINS: constant(int128) = 2
+PRECISION: constant(int128) = 10 ** 18
+
+FEE_DENOMINATOR: constant(uint256) = 10 ** 10
+
+A_PRECISION: constant(uint256) = 100
+MAX_A: constant(uint256) = 10 ** 6
+MAX_A_CHANGE: constant(uint256) = 10
+MIN_RAMP_TIME: constant(uint256) = 86400
+ADMIN_ACTIONS_DELAY: constant(uint256) = 3 * 86400
+### peggie rate; set prior to compiling; this RATES set to be 1e18
+RATES: constant(uint256) = 1000000000000000000     
+###  fetched redemption price has 27 decimals, scale to match 18 decmials
+REDMPTION_PRICE_SCALE: constant(uint256) = 10 ** 9   
+
+MAX_ADMIN_FEE: constant(uint256) = 10 * 10 ** 9
+MAX_FEE: constant(uint256) = 5 * 10 ** 9
+future_fee: public(uint256)
+future_admin_fee: public(uint256)
+fee: public(uint256)  # fee * 1e10
+admin_fee: public(uint256)  # admin_fee * 1e10
+
+
+# owner, lp tokern
+owner: public(address)
+lp_token: public(address)
+
+coins: public(address[N_COINS])
+balances: public(uint256[N_COINS])
+
+redemption_price_snap: public(address)  ### address to get redemption price snap
+
+
+initial_A: public(uint256)
+future_A: public(uint256)
+initial_A_time: public(uint256)
+future_A_time: public(uint256)
+
+admin_actions_deadline: public(uint256)
+transfer_ownership_deadline: public(uint256)
+future_owner: public(address)
+
+
+is_killed: bool
+kill_deadline: uint256
+KILL_DEADLINE_DT: constant(uint256) = 2 * 30 * 86400
+
+
+@external
+def __init__(
+    _owner: address,
+    _coins: address[N_COINS], 
+    _pool_token: address,                ### lp token address
+    _redemption_price_snap: address,     ### initialise rp snap address
+    _A: uint256,
+    _fee: uint256,
+    _admin_fee: uint256
+):
+    """
+    @notice Contract constructor
+    @param _owner Contract owner address
+    @param _coins Addresses of ERC20 conracts of coins
+    @param _pool_token Address of the token representing LP share
+    @param _redemption_price_snap Address of contract providing snapshot of redemption price  
+    @param _A Amplification coefficient multiplied by n ** (n - 1)
+    @param _fee Fee to charge for exchanges
+    @param _admin_fee Admin fee
+    """
+
+    for i in range(N_COINS):
+        coin: address = _coins[i]
+        if coin == ZERO_ADDRESS:
+            break
+        self.coins[i] = coin
+        # assert _rate_multipliers[i] == PRECISION
+
+    A: uint256 = _A * A_PRECISION
+    self.initial_A = A
+    self.future_A = A
+    self.fee = _fee
+    self.admin_fee = _admin_fee
+    # set owner
+    self.owner = _owner
+    self.kill_deadline = block.timestamp + KILL_DEADLINE_DT
+
+    ### Initialise rp snap address
+    self.redemption_price_snap = _redemption_price_snap
+    ### LP Token Address
+    self.lp_token = _pool_token
+
+    # fire a transfer event so block explorers identify the contract as an ERC20
+    log Transfer(ZERO_ADDRESS, self, 0)
+
+
+### StableSwap Functionality ###
+
+@view
+@external
+def get_balances() -> uint256[N_COINS]:
+    return self.balances
+
+
+@view
+@internal
+def _A() -> uint256:
+    """
+    Handle ramping A up or down
+    """
+    t1: uint256 = self.future_A_time
+    A1: uint256 = self.future_A
+
+    if block.timestamp < t1:
+        A0: uint256 = self.initial_A
+        t0: uint256 = self.initial_A_time
+        # Expressions in uint256 cannot have negative numbers, thus "if"
+        if A1 > A0:
+            return A0 + (A1 - A0) * (block.timestamp - t0) / (t1 - t0)
+        else:
+            return A0 - (A0 - A1) * (block.timestamp - t0) / (t1 - t0)
+
+    else:  # when t1 == 0 or block.timestamp >= t1
+        return A1
+
+### Reads a snapshot view of redemption price
+@view
+@internal
+def _get_scaled_redemption_price() -> uint256:
+    """
+    @notice Reads a snapshot view of redemption price
+    @dev The fetched redemption price uses 27 decimals
+    @return The redemption price with appropriate scaling to match LP tokens vitual price.
+    """
+    rate: uint256 = RedemptionPriceSnap(self.redemption_price_snap).snappedRedemptionPrice()
+    return rate / REDMPTION_PRICE_SCALE
+
+
+@view
+@external
+def A() -> uint256:
+    return self._A() / A_PRECISION
+
+
+@view
+@external
+def A_precise() -> uint256:
+    return self._A()
+
+
+### calculate _xp by self coin's balance and coin's price
+@view
+@internal
+def _xp() -> uint256[N_COINS]:
+    result: uint256[N_COINS] = [self._get_scaled_redemption_price(), RATES]
+    for i in range(N_COINS):
+        result[i] = result[i] * self.balances[i] / PRECISION
+    return result
+
+
+### calculate _xp_mem by coin's balance and coin's price
+@view
+@internal
+def _xp_mem(_balances: uint256[N_COINS]) -> uint256[N_COINS]:
+    result: uint256[N_COINS] = [self._get_scaled_redemption_price(), RATES]
+    for i in range(N_COINS):
+        result[i] = result[i] * _balances[i] / PRECISION
+    return result
+
+
+### D invariant calculation by _xp
+@pure
+@internal
+def _get_D(_xp: uint256[N_COINS], _amp: uint256) -> uint256:
+    """
+    D invariant calculation in non-overflowing integer operations
+    iteratively
+
+    A * sum(x_i) * n**n + D = A * D * n**n + D**(n+1) / (n**n * prod(x_i))
+
+    Converging solution:
+    D[j+1] = (A * n**n * sum(x_i) - D[j]**(n+1) / (n**n prod(x_i))) / (A * n**n - 1)
+    """
+    S: uint256 = 0
+    for x in _xp:
+        S += x
+    if S == 0:
+        return 0
+
+    D: uint256 = S
+    Ann: uint256 = _amp * N_COINS
+    for i in range(255):
+        D_P: uint256 = D * D / _xp[0] * D / _xp[1] / (N_COINS)**2
+        Dprev: uint256 = D
+        D = (Ann * S / A_PRECISION + D_P * N_COINS) * D / ((Ann - A_PRECISION) * D / A_PRECISION + (N_COINS + 1) * D_P)
+        # Equality with the precision of 1
+        if D > Dprev:
+            if D - Dprev <= 1:
+                return D
+        else:
+            if Dprev - D <= 1:
+                return D
+    # convergence typically occurs in 4 rounds or less, this should be unreachable!
+    # if it does happen the pool is borked and LPs can withdraw via `remove_liquidity`
+    raise
+
+### D invariant calculation by balance and price
+@view
+@internal
+def _get_D_mem(_balances: uint256[N_COINS], _amp: uint256) -> uint256:
+    return self._get_D(self._xp_mem(_balances), _amp)
+
+
+@view
+@external
+def get_virtual_price() -> uint256:
+    """
+    @notice The current virtual price of the pool LP token
+    @dev Useful for calculating profits
+    @return LP token virtual price normalized to 1e18
+    """
+    amp: uint256 = self._A()
+    D: uint256 = self._get_D(self._xp(), amp)   ### _xp as the input
+    # D is in the units similar to DAI (e.g. converted to precision 1e18)
+    # When balanced, D = n * x_u - total virtual value of the portfolio
+    token_supply: uint256 = ERC20(self.lp_token).totalSupply()
+    return D * PRECISION / token_supply
+
+
+@view
+@external
+def calc_token_amount(_amounts: uint256[N_COINS], _is_deposit: bool) -> uint256:
+    """
+    @notice Calculate addition or reduction in token supply from a deposit or withdrawal
+    @dev This calculation accounts for slippage, but not fees.
+         Needed to prevent front-running, not for precise calculations!
+    @param _amounts Amount of each coin being deposited
+    @param _is_deposit set True for deposits, False for withdrawals
+    @return Expected amount of LP tokens received
+    """
+    amp: uint256 = self._A()
+    balances: uint256[N_COINS] = self.balances
+    D0: uint256 = self._get_D_mem(balances, amp)   ###
+    for i in range(N_COINS):
+        amount: uint256 = _amounts[i]
+        if _is_deposit:
+            balances[i] += amount
+        else:
+            balances[i] -= amount
+    D1: uint256 = self._get_D_mem(balances, amp)   ###
+    token_amount: uint256 = CurveToken(self.lp_token).totalSupply()
+    diff: uint256 = 0
+    if _is_deposit:
+        diff = D1 - D0
+    else:
+        diff = D0 - D1
+    return diff * token_amount / D0
+
+
+@external
+@nonreentrant('lock')
+def add_liquidity(
+    _amounts: uint256[N_COINS],
+    _min_mint_amount: uint256
+) -> uint256:
+    """
+    @notice Deposit coins into the pool
+    @param _amounts List of amounts of coins to deposit
+    @param _min_mint_amount Minimum amount of LP tokens to mint from the deposit
+    @return Amount of LP tokens received by depositing
+    """
+    assert not self.is_killed  # dev: is killed
+
+    amp: uint256 = self._A()
+    old_balances: uint256[N_COINS] = self.balances
+
+    # Initial invariant
+    D0: uint256 = self._get_D_mem(old_balances, amp)   ###
+
+    total_supply: uint256 = CurveToken(self.lp_token).totalSupply()
+    new_balances: uint256[N_COINS] = old_balances
+    for i in range(N_COINS):
+        amount: uint256 = _amounts[i]
+        if total_supply == 0:
+            assert amount > 0  # dev: initial deposit requires all coins
+        new_balances[i] += amount
+
+    # Invariant after change
+    D1: uint256 = self._get_D_mem(new_balances, amp)
+    assert D1 > D0
+
+    # We need to recalculate the invariant accounting for fees
+    # to calculate fair user's share
+    fees: uint256[N_COINS] = empty(uint256[N_COINS])
+    mint_amount: uint256 = 0
+    if total_supply > 0:
+        # Only account for fees if we are not the first to deposit
+        base_fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+        for i in range(N_COINS):
+            ideal_balance: uint256 = D1 * old_balances[i] / D0
+            difference: uint256 = 0
+            new_balance: uint256 = new_balances[i]
+            if ideal_balance > new_balance:
+                difference = ideal_balance - new_balance
+            else:
+                difference = new_balance - ideal_balance
+            fees[i] = base_fee * difference / FEE_DENOMINATOR
+            self.balances[i] = new_balance - (fees[i] * self.admin_fee / FEE_DENOMINATOR)
+            new_balances[i] -= fees[i]
+        D2: uint256 = self._get_D_mem(new_balances, amp)    ###
+        mint_amount = total_supply * (D2 - D0) / D0
+    else:
+        # No fee if you are the first to deposit
+        self.balances = new_balances
+        mint_amount = D1  # Take the dust if there was any
+
+    assert mint_amount >= _min_mint_amount, "Slippage screwed you"
+
+    # Take coins from the sender
+    for i in range(N_COINS):
+        amount: uint256 = _amounts[i]
+        if amount > 0:
+            # "safeTransferFrom" which works for ERC20s which return bool or not
+            _response: Bytes[32] = raw_call(
+                self.coins[i],
+                concat(
+                    method_id("transferFrom(address,address,uint256)"),
+                    convert(msg.sender, bytes32),
+                    convert(self, bytes32),
+                    convert(amount, bytes32),
+                ),
+                max_outsize=32,
+            )
+            if len(_response) > 0:
+                assert convert(_response, bool)  # dev: failed transfer
+            # end "safeTransferFrom"
+
+    # Mint pool tokens
+    CurveToken(self.lp_token).mint(msg.sender, mint_amount)
+    log Transfer(ZERO_ADDRESS, msg.sender, mint_amount)
+
+    log AddLiquidity(msg.sender, _amounts, fees, D1, total_supply + mint_amount)
+
+    return mint_amount
+
+
+
+@view
+@internal
+def _get_y(i: int128, j: int128, x: uint256, xp: uint256[N_COINS]) -> uint256:
+    """
+    Calculate x[j] if one makes x[i] = x
+
+    Done by solving quadratic equation iteratively.
+    x_1**2 + x_1 * (sum' - (A*n**n - 1) * D / (A * n**n)) = D ** (n + 1) / (n ** (2 * n) * prod' * A)
+    x_1**2 + b*x_1 = c
+
+    x_1 = (x_1**2 + c) / (2*x_1 + b)
+    """
+    # x in the input is converted to the same price/precision
+
+    assert i != j       # dev: same coin
+    assert j >= 0       # dev: j below zero
+    assert j < N_COINS  # dev: j above N_COINS
+
+    # should be unreachable, but good for safety
+    assert i >= 0
+    assert i < N_COINS
+
+    amp: uint256 = self._A()
+    D: uint256 = self._get_D(xp, amp)     ###
+    S_: uint256 = 0
+    _x: uint256 = 0
+    y_prev: uint256 = 0
+    c: uint256 = D
+    Ann: uint256 = amp * N_COINS
+
+    for _i in range(N_COINS):
+        if _i == i:
+            _x = x
+        elif _i != j:
+            _x = xp[_i]
+        else:
+            continue
+        S_ += _x
+        c = c * D / (_x * N_COINS)
+
+    c = c * D * A_PRECISION / (Ann * N_COINS)
+    b: uint256 = S_ + D * A_PRECISION / Ann  # - D
+    y: uint256 = D
+
+    for _i in range(255):
+        y_prev = y
+        y = (y*y + c) / (2 * y + b - D)
+        # Equality with the precision of 1
+        if y > y_prev:
+            if y - y_prev <= 1:
+                return y
+        else:
+            if y_prev - y <= 1:
+                return y
+    raise
+
+### Get the new price to calculate the current output dy given input dx
+@view
+@external
+def get_dy(i: int128, j: int128, dx: uint256) -> uint256:
+    """
+    @notice Calculate the current output dy given input dx
+    @dev Index values can be found via the `coins` public getter method
+    @param i Index value for the coin to send
+    @param j Index valie of the coin to recieve
+    @param dx Amount of `i` being exchanged
+    @return Amount of `j` predicted
+    """
+
+    xp: uint256[N_COINS] = self._xp()    ###
+    ### get coin price
+    rates: uint256[N_COINS] = [self._get_scaled_redemption_price(), RATES]
+
+    x: uint256 = xp[i] + (dx * rates[i] / PRECISION)         ###     
+    y: uint256 = self._get_y(i, j, x, xp)
+    dy: uint256 = xp[j] - y - 1
+    fee: uint256 = self.fee * dy / FEE_DENOMINATOR
+    return (dy - fee) * PRECISION / rates[j]                ###
+
+
+### Perform an exchange between two coins
+@external
+@nonreentrant('lock')
+def exchange(
+    i: int128,
+    j: int128,
+    _dx: uint256,
+    _min_dy: uint256
+) -> uint256:
+    """
+    @notice Perform an exchange between two coins
+    @dev Index values can be found via the `coins` public getter method
+    @param i Index value for the coin to send
+    @param j Index valie of the coin to recieve
+    @param _dx Amount of `i` being exchanged
+    @param _min_dy Minimum amount of `j` to receive
+    @return Actual amount of `j` received
+    """
+    assert not self.is_killed  # dev: is killed
+    old_balances: uint256[N_COINS] = self.balances
+
+    xp: uint256[N_COINS] = self._xp_mem(old_balances)        ### 
+    rates: uint256[N_COINS] = [self._get_scaled_redemption_price(), RATES]   ###
+    x: uint256 = xp[i] + _dx * rates[i] / PRECISION     ###
+
+    y: uint256 = self._get_y(i, j, x, xp)
+
+    dy: uint256 = xp[j] - y - 1  # -1 just in case there were some rounding errors
+    dy_fee: uint256 = dy * self.fee / FEE_DENOMINATOR
+
+    # Convert all to real units
+    dy = (dy - dy_fee) * PRECISION / rates[j]
+    assert dy >= _min_dy, "Exchange resulted in fewer coins than expected"
+
+    dy_admin_fee: uint256 = dy_fee * self.admin_fee / FEE_DENOMINATOR
+    dy_admin_fee = dy_admin_fee * PRECISION / rates[j]
+
+    # Change balances exactly in same way as we change actual ERC20 coin amounts
+    self.balances[i] = old_balances[i] + _dx
+    # When rounding errors happen, we undercharge admin fee in favor of LP
+    self.balances[j] = old_balances[j] - dy - dy_admin_fee
+
+    _response: Bytes[32] = raw_call(
+        self.coins[i],
+        concat(
+            method_id("transferFrom(address,address,uint256)"),
+            convert(msg.sender, bytes32),
+            convert(self, bytes32),
+            convert(_dx, bytes32),
+        ),
+        max_outsize=32,
+    )
+    if len(_response) > 0:
+        assert convert(_response, bool)
+
+    _response = raw_call(
+        self.coins[j],
+        concat(
+            method_id("transfer(address,uint256)"),
+            convert(msg.sender, bytes32),
+            convert(dy, bytes32),
+        ),
+        max_outsize=32,
+    )
+    if len(_response) > 0:
+        assert convert(_response, bool)
+
+    log TokenExchange(msg.sender, i, _dx, j, dy)
+
+    return dy
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity(
+    _burn_amount: uint256,
+    _min_amounts: uint256[N_COINS]
+) -> uint256[N_COINS]:
+    """
+    @notice Withdraw coins from the pool
+    @dev Withdrawal amounts are based on current deposit ratios
+    @param _burn_amount Quantity of LP tokens to burn in the withdrawal
+    @param _min_amounts Minimum amounts of underlying coins to receive
+    @return List of amounts of coins that were withdrawn
+    """
+    lp_token: address = self.lp_token
+    total_supply: uint256 = CurveToken(self.lp_token).totalSupply()
+    amounts: uint256[N_COINS] = empty(uint256[N_COINS])
+
+    # remove liquidity by the ratio of _burn_amount in total_supply
+    for i in range(N_COINS):
+        old_balance: uint256 = self.balances[i]
+        value: uint256 = old_balance * _burn_amount / total_supply
+        assert value >= _min_amounts[i], "Withdrawal resulted in fewer coins than expected"
+        self.balances[i] = old_balance - value
+        amounts[i] = value
+
+        _response: Bytes[32] = raw_call(
+            self.coins[i],
+            concat(
+                method_id("transfer(address,uint256)"),
+                convert(msg.sender, bytes32),
+                convert(value, bytes32),
+            ),
+            max_outsize=32,
+        )
+        if len(_response) > 0:
+            assert convert(_response, bool)
+
+    CurveToken(self.lp_token).burnFrom(msg.sender, _burn_amount)  # dev: insufficient funds
+    log Transfer(msg.sender, ZERO_ADDRESS, _burn_amount)
+
+    log RemoveLiquidity(msg.sender, amounts, empty(uint256[N_COINS]), total_supply - _burn_amount)
+
+    return amounts
+
+### Withdraw coins from the pool in an imbalanced amount
+@external
+@nonreentrant('lock')
+def remove_liquidity_imbalance(
+    _amounts: uint256[N_COINS],
+    _max_burn_amount: uint256
+) -> uint256:
+    """
+    @notice Withdraw coins from the pool in an imbalanced amount
+    @param _amounts List of amounts of underlying coins to withdraw
+    @param _max_burn_amount Maximum amount of LP token to burn in the withdrawal
+    @return Actual amount of the LP token burned in the withdrawal
+    """
+    assert not self.is_killed  # dev: is killed
+    amp: uint256 = self._A()
+    old_balances: uint256[N_COINS] = self.balances
+    D0: uint256 = self._get_D_mem(old_balances, amp)    ###
+
+    new_balances: uint256[N_COINS] = old_balances
+    for i in range(N_COINS):
+        new_balances[i] -= _amounts[i]
+    D1: uint256 = self._get_D_mem(new_balances, amp)    ###
+
+    fees: uint256[N_COINS] = empty(uint256[N_COINS])
+    base_fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+    for i in range(N_COINS):
+        ideal_balance: uint256 = D1 * old_balances[i] / D0
+        difference: uint256 = 0
+        new_balance: uint256 = new_balances[i]
+        if ideal_balance > new_balance:
+            difference = ideal_balance - new_balance
+        else:
+            difference = new_balance - ideal_balance
+        fees[i] = base_fee * difference / FEE_DENOMINATOR
+        self.balances[i] = new_balance - (fees[i] * self.admin_fee / FEE_DENOMINATOR)
+        new_balances[i] -= fees[i]
+    D2: uint256 = self._get_D_mem(new_balances, amp)
+
+    lp_token: address = self.lp_token
+    total_supply: uint256 = CurveToken(self.lp_token).totalSupply()
+    burn_amount: uint256 = ((D0 - D2) * total_supply / D0) + 1
+    assert burn_amount > 1  # dev: zero tokens burned
+    assert burn_amount <= _max_burn_amount, "Slippage screwed you"
+
+    CurveToken(self.lp_token).burnFrom(msg.sender, burn_amount)  # dev: insufficient funds
+    log Transfer(msg.sender, ZERO_ADDRESS, burn_amount)
+
+    for i in range(N_COINS):
+        if _amounts[i] != 0:
+            _response: Bytes[32] = raw_call(
+                self.coins[i],
+                concat(
+                    method_id("transfer(address,uint256)"),
+                    convert(msg.sender, bytes32),
+                    convert(_amounts[i], bytes32),
+                ),
+                max_outsize=32,
+            )
+            if len(_response) > 0:
+                assert convert(_response, bool)
+
+    log RemoveLiquidityImbalance(msg.sender, _amounts, fees, D1, total_supply - burn_amount)
+
+    return burn_amount
+
+
+@pure
+@internal
+def _get_y_D(A: uint256, i: int128, xp: uint256[N_COINS], D: uint256) -> uint256:
+    """
+    Calculate x[i] if one reduces D from being calculated for xp to D
+
+    Done by solving quadratic equation iteratively.
+    x_1**2 + x_1 * (sum' - (A*n**n - 1) * D / (A * n**n)) = D ** (n + 1) / (n ** (2 * n) * prod' * A)
+    x_1**2 + b*x_1 = c
+
+    x_1 = (x_1**2 + c) / (2*x_1 + b)
+    """
+    # x in the input is converted to the same price/precision
+
+    assert i >= 0  # dev: i below zero
+    assert i < N_COINS  # dev: i above N_COINS
+
+    S_: uint256 = 0
+    _x: uint256 = 0
+    y_prev: uint256 = 0
+    c: uint256 = D
+    Ann: uint256 = A * N_COINS
+
+    for _i in range(N_COINS):
+        if _i != i:
+            _x = xp[_i]
+        else:
+            continue
+        S_ += _x
+        c = c * D / (_x * N_COINS)
+
+    c = c * D * A_PRECISION / (Ann * N_COINS)
+    b: uint256 = S_ + D * A_PRECISION / Ann
+    y: uint256 = D
+
+    for _i in range(255):
+        y_prev = y
+        y = (y*y + c) / (2 * y + b - D)
+        # Equality with the precision of 1
+        if y > y_prev:
+            if y - y_prev <= 1:
+                return y
+        else:
+            if y_prev - y <= 1:
+                return y
+    raise
+
+### Calculate the amount of i coin to withdraw when burning  _burn_amount amount of LP tokens
+### Need to get new price
+@view
+@internal
+def _calc_withdraw_one_coin(_burn_amount: uint256, i: int128) -> uint256[2]:
+    # First, need to calculate
+    # * Get current D
+    # * Solve Eqn against y_i for D - _token_amount
+    amp: uint256 = self._A()
+    xp: uint256[N_COINS] = self._xp()         ###
+    D0: uint256 = self._get_D(xp, amp)        ###
+
+    total_supply: uint256 = CurveToken(self.lp_token).totalSupply()
+    D1: uint256 = D0 - _burn_amount * D0 / total_supply
+    new_y: uint256 = self._get_y_D(amp, i, xp, D1)     ###
+
+    base_fee: uint256 = self.fee * N_COINS / (4 * (N_COINS - 1))
+    xp_reduced: uint256[N_COINS] = xp               ###
+    rates: uint256[N_COINS] = [self._get_scaled_redemption_price(), RATES]
+
+    for j in range(N_COINS):
+        dx_expected: uint256 = 0
+        if j == i:
+            dx_expected = xp[j] * D1 / D0 - new_y      ###
+        else:
+            dx_expected = xp[j] - xp[j] * D1 / D0      ###
+        xp_reduced[j] -= self.fee * dx_expected / FEE_DENOMINATOR    ###
+    dy: uint256 = xp_reduced[i] - self._get_y_D(amp, i, xp_reduced, D1)              ###
+    dy = (dy - 1) * PRECISION / rates[i]  # Withdraw less to account for rounding errors         ###
+    dy_0: uint256 = (xp[i] - new_y) * PRECISION / rates[i]  # w/o fees         ###
+
+    return [dy, dy_0 - dy]
+
+
+@view
+@external
+def calc_withdraw_one_coin(_burn_amount: uint256, i: int128, _previous: bool = False) -> uint256:
+    """
+    @notice Calculate the amount received when withdrawing a single coin
+    @param _burn_amount Amount of LP tokens to burn in the withdrawal
+    @param i Index value of the coin to withdraw
+    @return Amount of coin received
+    """
+    return self._calc_withdraw_one_coin(_burn_amount, i)[0]
+
+
+@external
+@nonreentrant('lock')
+def remove_liquidity_one_coin(
+    _burn_amount: uint256,
+    i: int128,
+    _min_received: uint256
+) -> uint256:
+    """
+    @notice Withdraw a single coin from the pool
+    @param _burn_amount Amount of LP tokens to burn in the withdrawal
+    @param i Index value of the coin to withdraw
+    @param _min_received Minimum amount of coin to receive
+    @return Amount of coin received
+    """
+    assert not self.is_killed  # dev: is killed
+    dy: uint256[2] = self._calc_withdraw_one_coin(_burn_amount, i)
+    assert dy[0] >= _min_received, "Not enough coins removed"
+
+    # update balances
+    self.balances[i] -= (dy[0] + dy[1] * self.admin_fee / FEE_DENOMINATOR)
+    CurveToken(self.lp_token).burnFrom(msg.sender, _burn_amount)  # dev: insufficient funds
+    log Transfer(msg.sender, ZERO_ADDRESS, _burn_amount)
+
+    _response: Bytes[32] = raw_call(
+        self.coins[i],
+        concat(
+            method_id("transfer(address,uint256)"),
+            convert(msg.sender, bytes32),
+            convert(dy[0], bytes32),
+        ),
+        max_outsize=32,
+    )
+    if len(_response) > 0:
+        assert convert(_response, bool)
+    
+    total_supply: uint256 = CurveToken(self.lp_token).totalSupply()
+    log RemoveLiquidityOne(msg.sender, _burn_amount, dy[0], total_supply)
+
+    return dy[0]
+
+
+@external
+def ramp_A(_future_A: uint256, _future_time: uint256):
+    assert msg.sender == self.owner  # dev: only owner
+    assert block.timestamp >= self.initial_A_time + MIN_RAMP_TIME
+    assert _future_time >= block.timestamp + MIN_RAMP_TIME  # dev: insufficient time
+
+    _initial_A: uint256 = self._A()
+    _future_A_p: uint256 = _future_A * A_PRECISION
+
+    assert _future_A > 0 and _future_A < MAX_A
+    if _future_A_p < _initial_A:
+        assert _future_A_p * MAX_A_CHANGE >= _initial_A
+    else:
+        assert _future_A_p <= _initial_A * MAX_A_CHANGE
+
+    self.initial_A = _initial_A
+    self.future_A = _future_A_p
+    self.initial_A_time = block.timestamp
+    self.future_A_time = _future_time
+
+    log RampA(_initial_A, _future_A_p, block.timestamp, _future_time)
+
+
+@external
+def stop_ramp_A():
+    assert msg.sender == self.owner  # dev: only owner
+
+    current_A: uint256 = self._A()
+    self.initial_A = current_A
+    self.future_A = current_A
+    self.initial_A_time = block.timestamp
+    self.future_A_time = block.timestamp
+    # now (block.timestamp < t1) is always False, so we return saved A
+
+    log StopRampA(current_A, block.timestamp)
+
+
+@external
+def commit_new_fee(_new_fee: uint256, _new_admin_fee: uint256):
+    assert msg.sender == self.owner  # dev: only owner
+    assert self.admin_actions_deadline == 0  # dev: active action
+    assert _new_fee <= MAX_FEE  # dev: fee exceeds maximum
+    assert _new_admin_fee <= MAX_ADMIN_FEE  # dev: admin fee exceeds maximum
+
+    deadline: uint256 = block.timestamp + ADMIN_ACTIONS_DELAY
+    self.admin_actions_deadline = deadline
+    self.future_fee = _new_fee
+    self.future_admin_fee = _new_admin_fee
+
+    log CommitNewFee(deadline, _new_fee, _new_admin_fee)
+
+
+@external
+def apply_new_fee():
+    assert msg.sender == self.owner  # dev: only owner
+    assert block.timestamp >= self.admin_actions_deadline  # dev: insufficient time
+    assert self.admin_actions_deadline != 0  # dev: no active action
+
+    self.admin_actions_deadline = 0
+    fee: uint256 = self.future_fee
+    admin_fee: uint256 = self.future_admin_fee
+    self.fee = fee
+    self.admin_fee = admin_fee
+
+    log NewFee(fee, admin_fee)
+
+@external
+def revert_new_parameters():
+    assert msg.sender == self.owner  # dev: only owner
+
+    self.admin_actions_deadline = 0
+
+
+@external
+def commit_transfer_ownership(_owner: address):
+    assert msg.sender == self.owner  # dev: only owner
+    assert self.transfer_ownership_deadline == 0  # dev: active transfer
+
+    deadline: uint256 = block.timestamp + ADMIN_ACTIONS_DELAY
+    self.transfer_ownership_deadline = deadline
+    self.future_owner = _owner
+
+    log CommitNewAdmin(deadline, _owner)
+
+@external
+def apply_transfer_ownership():
+    assert msg.sender == self.owner  # dev: only owner
+    assert block.timestamp >= self.transfer_ownership_deadline  # dev: insufficient time
+    assert self.transfer_ownership_deadline != 0  # dev: no active transfer
+
+    self.transfer_ownership_deadline = 0
+    owner: address = self.future_owner
+    self.owner = owner
+
+    log NewAdmin(owner)
+
+
+@external
+def revert_transfer_ownership():
+    assert msg.sender == self.owner  # dev: only owner
+
+    self.transfer_ownership_deadline = 0
+
+
+
+@view
+@external
+def admin_balances(i: uint256) -> uint256:
+    return ERC20(self.coins[i]).balanceOf(self) - self.balances[i]
+
+
+@external
+def withdraw_admin_fees():
+    assert msg.sender == self.owner  # dev: only owner
+
+    for i in range(N_COINS):
+        coin: address = self.coins[i]
+        fees: uint256 = ERC20(coin).balanceOf(self) - self.balances[i]
+
+        if fees > 0:
+            ERC20(coin).transfer(msg.sender, fees)
+
+
+@external
+def kill_me():
+    assert msg.sender == self.owner  # dev: only owner
+    assert self.kill_deadline > block.timestamp  # dev: deadline has passed
+    self.is_killed = True
+
+
+@external
+def unkill_me():
+    assert msg.sender == self.owner  # dev: only owner
+    self.is_killed = False

--- a/contracts/pools/raiust/pooldata.json
+++ b/contracts/pools/raiust/pooldata.json
@@ -1,0 +1,31 @@
+{
+    "pool_types": ["arate"],
+    "lp_contract": "CurveTokenV3", 
+    "lp_token_address": "0x0000000000000000000000000000000000000000",
+    "swap_address": "0x0000000000000000000000000000000000000000",
+    "gauge_addresses": ["0x0000000000000000000000000000000000000000"],
+    "lp_constructor": {
+        "symbol": "Raiust",
+        "name": "Curve.fi RAI/UST"
+    },
+    "swap_constructor": {
+        "_redemption_price_snap": "0x0000000000000000000000000000000000000000",
+        "_A": 100,
+        "_fee": 4000000
+    },
+    "coins": [
+        {
+            "name": "RAI",
+            "decimals": 18,
+            "tethered": false,
+            "underlying_address": "0x03ab458634910AaD20eF5f1C8ee96F1D6ac54919"
+        },
+        {
+            "name": "UST",
+            "decimals": 18,
+            "tethered": false,
+            "underlying_address": "0xa47c8bf37f92aBed4A126BDA807A7b7498661acD"
+
+        }
+    ]
+}

--- a/tests/fixtures/deployments.py
+++ b/tests/fixtures/deployments.py
@@ -134,7 +134,7 @@ def aave_lending_pool(AaveLendingPoolMock, pool_data, alice, is_forked):
 
 @pytest.fixture(scope="module")
 def redemption_price_snap(RedemptionPriceSnapMock, pool_data, alice, is_forked):
-    if pool_data["name"] in ("rai",):
+    if pool_data["name"] in ("rai", "raiust"):
         if is_forked:
             return Contract("0x0000000000000000000000000000000000000000")  # todo after deployment replace this.
         else:

--- a/tests/pools/raiust/integration/test_rp_moving_raiust.py
+++ b/tests/pools/raiust/integration/test_rp_moving_raiust.py
@@ -1,0 +1,181 @@
+import pytest
+from brownie import ETH_ADDRESS, chain
+from brownie.test import strategy
+
+pytestmark = [pytest.mark.usefixtures("add_initial_liquidity")]
+
+class StateMachine:
+    """
+    Stateful test that performs a series of deposits, swaps and withdrawals
+    and confirms that the virtual price only goes up.
+    """
+    # a decimal number between 0.5 and 1 with two points
+    st_pct = strategy("decimal", min_value="0.5", max_value="1", places=2)
+    ### set red_prices, red price has 27 decimals, here is 0.98 to 1.02
+    st_red_prices = strategy('uint256',
+                             min_value="980000000000000000000000000",
+                             max_value="1020000000000000000000000000")
+    st_rates = strategy("decimal[8]", min_value="1.001", max_value="1.004", places=4, unique=True)
+
+    def __init__(cls, alice, swap, wrapped_coins, wrapped_decimals, redemption_price_snap):
+        cls.alice = alice
+        cls.swap = swap
+        cls.coins = wrapped_coins
+        cls.decimals = wrapped_decimals
+        cls.n_coins = len(wrapped_coins)
+        ### add rp snap
+        cls.redemption_price_snap = redemption_price_snap
+
+    # update LP Token Price and redemption price
+    def setup(self):
+        # reset the virtual price between each test run
+        self.virtual_price = self.swap.get_virtual_price()
+        ### update the rp
+        self.redemption_price = self.redemption_price_snap.snappedRedemptionPrice()
+
+    # get index values for the coins with the smallest and largest balances in the pool
+    def _min_max(self):
+        # get index values for the coins with the smallest and largest balances in the pool
+        balances = [self.swap.balances(i) / (10 ** self.decimals[i]) for i in range(self.n_coins)]
+        min_idx = balances.index(min(balances))
+        max_idx = balances.index(max(balances))
+        if min_idx == max_idx:
+            min_idx = abs(min_idx - 1)
+
+        return min_idx, max_idx
+
+    def rule_ramp_A(self, st_pct):
+        """
+        Increase the amplification coefficient.
+
+        This action happens at most once per test. If A has already
+        been ramped, a swap is performed instead.
+        """
+        ## if swap has no ramp_A or swap is set to have no ramp_A, exchange directly.
+        if not hasattr(self.swap, "ramp_A") or self.swap.future_A_time():
+            return self.rule_exchange_underlying(st_pct)
+
+        # increase A
+        new_A = int(self.swap.A() * (1 + st_pct))
+        self.swap.ramp_A(new_A, chain.time() + 86410, {"from": self.alice})
+
+
+    ### Adpat RP
+    def rule_adjust_redemption_price(self, st_red_prices):
+        self.redemption_price_snap.setRedemptionPriceSnap(st_red_prices)
+
+
+    def rule_increase_rates(self, st_rates):
+        """
+        Increase the stored rate for each wrapped coin.
+        """
+        for rate, coin in zip(self.coins, st_rates):
+            if hasattr(coin, "set_exchange_rate"):
+                coin.set_exchange_rate(int(coin.get_rate() * rate), {"from": self.alice})
+
+    # send min-indexed coin, and receive max-indexed coin
+    def rule_exchange(self, st_pct):
+        """
+        Perform a swap using wrapped coins.
+        """
+        send, recv = self._min_max()
+        amount = int(10 ** self.decimals[send] * st_pct)
+        value = amount if self.coins[send] == ETH_ADDRESS else 0
+        self.swap.exchange(send, recv, amount, 0, {"from": self.alice, "value": value})
+
+    # swap must have exchange_underlying, otherwise directly swap (rule_exchange)
+    def rule_exchange_underlying(self, st_pct):
+        """
+        Perform a swap using underlying coins.
+        """
+        if not hasattr(self.swap, "exchange_underlying"):
+            # if underlying coins aren't available, use wrapped instead
+            return self.rule_exchange(st_pct)
+
+        send, recv = self._min_max()
+        amount = int(10 ** self.decimals[send] * st_pct)
+        value = amount if self.coins[send] == ETH_ADDRESS else 0
+        self.swap.exchange_underlying(send, recv, amount, 0, {"from": self.alice, "value": value})
+
+    def rule_remove_one_coin(self, st_pct):
+        """
+        Remove liquidity from the pool in only one coin.
+        """
+        if not hasattr(self.swap, "remove_liquidity_one_coin"):
+            # not all pools include `remove_liquidity_one_coin`
+            return self.rule_remove_imbalance(st_pct)
+
+        # get max-indexed coin
+        idx = self._min_max()[1]
+        amount = int(10 ** self.decimals[idx] * st_pct)
+        self.swap.remove_liquidity_one_coin(amount, idx, 0, {"from": self.alice})
+
+    def rule_remove_imbalance(self, st_pct):
+        """
+        Remove liquidity from the pool in an imbalanced manner.
+        """
+        idx = self._min_max()[1]
+        amounts = [0] * self.n_coins
+        amounts[idx] = 10 ** self.decimals[idx] * st_pct
+        self.swap.remove_liquidity_imbalance(amounts, 2 ** 256 - 1, {"from": self.alice})
+
+    def rule_remove(self, st_pct):
+        """
+        Remove liquidity from the pool.
+        """
+        amount = int(10 ** 18 * st_pct)
+        self.swap.remove_liquidity(amount, [0] * self.n_coins, {"from": self.alice})
+
+    def invariant_check_virtual_price(self):
+        """
+        Verify that the pool's virtual price has either increased or stayed the same.
+        """
+        virtual_price = self.swap.get_virtual_price()
+        #### RP up, VP up 
+        redemption_price = self.redemption_price_snap.snappedRedemptionPrice()
+        if redemption_price >= self.redemption_price:
+            assert virtual_price + 1 >= self.virtual_price
+        ####
+        self.redemption_price = redemption_price
+        self.virtual_price = virtual_price
+
+    def invariant_advance_time(self):
+        """
+        Advance the clock by 1 hour between each action.
+        """
+        chain.sleep(3600)
+
+
+def test_number_always_go_up(
+    add_initial_liquidity,
+    state_machine,
+    swap,
+    alice,
+    bob,
+    underlying_coins,
+    wrapped_coins,
+    wrapped_decimals,
+    base_amount,
+    set_fees,
+    redemption_price_snap,
+):
+    set_fees(10 ** 7, 0)
+
+    for underlying, wrapped in zip(underlying_coins, wrapped_coins):
+        amount = 10 ** 18 * base_amount
+        if underlying == ETH_ADDRESS:
+            bob.transfer(alice, amount)
+        else:
+            underlying._mint_for_testing(alice, amount, {"from": alice})
+        if underlying != wrapped:
+            wrapped._mint_for_testing(alice, amount, {"from": alice})
+
+    state_machine(
+        StateMachine,
+        alice,
+        swap,
+        wrapped_coins,
+        wrapped_decimals,
+        redemption_price_snap,
+        settings={"max_examples": 25, "stateful_step_count": 50},
+    )

--- a/tests/pools/raiust/unitary/test_add_liquidity_initial_moving_rp_raiust.py
+++ b/tests/pools/raiust/unitary/test_add_liquidity_initial_moving_rp_raiust.py
@@ -1,0 +1,36 @@
+import brownie
+import pytest
+
+pytestmark = pytest.mark.usefixtures("mint_alice", "approve_alice")
+
+@pytest.mark.parametrize("redemption_price_scale", [0.5, 2])
+@pytest.mark.parametrize("min_amount", [0, 2 * 10 ** 18])
+def test_initial(
+    alice, swap, wrapped_coins, pool_token, min_amount, wrapped_decimals, n_coins, initial_amounts, 
+    redemption_price_scale, redemption_price_snap):
+    amounts = [10 ** i for i in wrapped_decimals]
+    ###
+    redemption_price_snap.setRedemptionPriceSnap(redemption_price_scale * 1e27)
+    imbalance_scale = 0.5 + 0.5 * redemption_price_scale
+    min_amount *= imbalance_scale * (1 - 1e-3)
+    swap.add_liquidity(amounts, min_amount, {"from": alice, "value": 0})
+
+    for coin, amount, initial in zip(wrapped_coins, amounts, initial_amounts):
+        assert coin.balanceOf(alice) == initial - amount
+        assert coin.balanceOf(swap) == amount
+
+    std_amount = (n_coins * 10 ** 18)
+    expected_balance = std_amount * imbalance_scale
+    assert pytest.approx(pool_token.balanceOf(alice), rel=1e-3) == expected_balance
+    assert pytest.approx(pool_token.totalSupply(), rel=1e-3) == expected_balance
+
+@pytest.mark.parametrize("redemption_price_scale", [0.5, 2])
+@pytest.mark.itercoins("idx")
+def test_initial_liquidity_missing_coin(alice, swap, pool_token, idx, wrapped_decimals, redemption_price_scale, redemption_price_snap):
+    redemption_price_snap.setRedemptionPriceSnap(redemption_price_scale * 1e27)
+    amounts = [10 ** i for i in wrapped_decimals]
+    # idx-indexed coin is missing
+    amounts[idx] = 0
+
+    with brownie.reverts():
+        swap.add_liquidity(amounts, 0, {"from": alice})

--- a/tests/pools/raiust/unitary/test_add_liquidity_moving_rp_raiust.py
+++ b/tests/pools/raiust/unitary/test_add_liquidity_moving_rp_raiust.py
@@ -1,0 +1,23 @@
+import pytest
+
+pytestmark = pytest.mark.usefixtures("add_initial_liquidity", "mint_bob", "approve_bob")
+lp_index = 1
+
+@pytest.mark.parametrize("redemption_price_scale", [0.5, 2])
+@pytest.mark.itercoins("zero_idx")
+def test_add_liquidity(bob, swap, wrapped_coins, pool_token, initial_amounts, base_amount, n_coins, zero_idx,
+                       redemption_price_scale, redemption_price_snap):
+    initial_pool_token_total_supply = pool_token.totalSupply()
+    new_to_initial_deposit_scale = 1e-21
+    deposit_amounts = [initial_amounts[i] * new_to_initial_deposit_scale for i in range(n_coins)]
+    deposit_amounts[zero_idx] = 0
+    redemption_price_snap.setRedemptionPriceSnap(redemption_price_scale * 1e27)
+    swap.add_liquidity(deposit_amounts, 0, {"from": bob, "value": 0})
+    pool_tokens_earned = pool_token.balanceOf(bob)
+
+    tvl_prop = 0.5 + 0.5 * redemption_price_scale  # half of liquidity val has been scaled by redemption price
+    deposited_coin_val = 1
+    if zero_idx == lp_index:
+        deposited_coin_val = redemption_price_scale
+    expected = initial_pool_token_total_supply * new_to_initial_deposit_scale / 2 * deposited_coin_val / tvl_prop
+    assert pytest.approx(pool_tokens_earned, rel=1e-3) == expected

--- a/tests/pools/raiust/unitary/test_exchange_moving_rp_raiust.py
+++ b/tests/pools/raiust/unitary/test_exchange_moving_rp_raiust.py
@@ -1,0 +1,30 @@
+import pytest
+from pytest import approx
+
+pytestmark = pytest.mark.usefixtures("add_initial_liquidity", "approve_bob")
+redemption_index = 0
+lp_index = 1
+
+@pytest.mark.parametrize("redemption_price_scale", [0.75, 1.0, 1.25])
+def test_exchange_results_with_moving_redemption_price(
+    bob,
+    swap,
+    wrapped_coins,
+    redemption_price_scale,
+    redemption_price_snap,
+):
+    redemption_coin = wrapped_coins[redemption_index]
+    lp_coin = wrapped_coins[lp_index]
+    precision = 10 ** 18
+    trade_quantity = 10 * precision
+    redemption_price_snap.setRedemptionPriceSnap(redemption_price_scale * 1e27)
+    redemption_coin._mint_for_testing(bob, trade_quantity, {"from": bob})
+    # send from redemption_index, receive from lp_index
+    swap.exchange(redemption_index, lp_index, trade_quantity, 0, {"from": bob, "value": 0})
+    assert redemption_coin.balanceOf(bob) == 0
+    received = lp_coin.balanceOf(bob)
+    assert trade_quantity * redemption_price_scale == approx(received, rel=1e-3)
+    # exchange back
+    swap.exchange(lp_index, redemption_index, received, 0, {"from": bob, "value": 0})
+    assert approx(redemption_coin.balanceOf(bob)) == trade_quantity
+    assert lp_coin.balanceOf(bob) == 0

--- a/tests/pools/raiust/unitary/test_remove_liquidity_imbalance_moving_rp_raiust.py
+++ b/tests/pools/raiust/unitary/test_remove_liquidity_imbalance_moving_rp_raiust.py
@@ -1,0 +1,88 @@
+import brownie
+import pytest
+
+pytestmark = pytest.mark.usefixtures("add_initial_liquidity")
+redemption_index = 0
+lp_index = 1
+
+@pytest.mark.parametrize("redemption_price_scale", [0.5, 2])
+@pytest.mark.itercoins("zero_idx")
+def test_remove_some_pool_token(alice, swap, wrapped_coins, pool_token, initial_amounts, n_coins, base_amount,
+                                redemption_price_scale, zero_idx, redemption_price_snap):
+    # Draw half amount of coins
+    amounts = [i // 2 for i in initial_amounts]
+    # imbalance, set one coin to draw 0
+    amounts[zero_idx] = 0
+
+    # Get the initianl LP Token
+    initial_pool_token_total_supply = pool_token.totalSupply()
+
+    # The redemption price is being doubled or halved, and half of either the redemption or base lp token is removed.
+    # Each component of liquidity now accounts for either one or two thirds of the total.
+    
+    # Update RP first, then remove
+    redemption_price_snap.setRedemptionPriceSnap(redemption_price_scale * 1e27)
+    swap.remove_liquidity_imbalance(amounts, n_coins * 10 ** 18 * base_amount, {"from": alice})
+    
+    # After remove, coin amount should change on the coin balance of swap and alice
+    for i, coin in enumerate(wrapped_coins):
+        assert coin.balanceOf(alice) == amounts[i]
+        assert coin.balanceOf(swap) == initial_amounts[i] - amounts[i]
+
+    # After remove liquidity, assure LP token has been burned
+    actual_balance = pool_token.balanceOf(alice)
+    actual_total_supply = pool_token.totalSupply()
+    assert actual_balance == actual_total_supply
+
+    # Ensure a fair amount of LP tokens have been destroyed relative to the proportion of total liquidity value removed.
+    # Approx used because there will be some small slippage.
+    # # # Case 1 Explanation:
+    # # # The initial proportion between R and L is 1:1, if redemption_price_scale is 2, then 
+    # # # the proportion between R and L is 2:1. Draw [0, 0.5], then remaining_proportion is 1.5/(2+1)= 5/6
+    # # # Case 2 Explanation:
+    # # # The initial proportion between R and L is 1:1, if redemption_price_scale is 0.5, then 
+    # # # the proportion between R and L is 0.5:1. Draw [0.25, 0], then remaining_proportion is 1.25/(0.5+1)= 5/6
+    if (zero_idx == redemption_index) == (redemption_price_scale == 2):
+        expected_pool_tokens_remaining_proportion = 5 / 6
+    else:
+        # Logic is the same as above
+        expected_pool_tokens_remaining_proportion = 2 / 3
+
+    remaining_proportion = actual_total_supply / initial_pool_token_total_supply
+
+    assert expected_pool_tokens_remaining_proportion == pytest.approx(remaining_proportion, rel=1e-3)
+
+
+@pytest.mark.parametrize("divisor", [1, 2, 10])
+@pytest.mark.parametrize("redemption_price_scale", [0.5, 2])
+def test_exceed_max_burn(alice, swap, wrapped_coins, pool_token, divisor, initial_amounts, base_amount, n_coins,
+                         redemption_price_scale, redemption_price_snap):
+    amounts = [i // divisor for i in initial_amounts]
+    max_burn = (n_coins * 10 ** 18 * base_amount) // divisor
+    redemption_price_snap.setRedemptionPriceSnap(redemption_price_scale * 1e27)
+
+    # Ensure when withdrawing equal amounts of each coin the redemption price should not effect results compared to the
+    # common version of this test.
+    with brownie.reverts("Slippage screwed you"):
+        swap.remove_liquidity_imbalance(amounts, max_burn - 1, {"from": alice})
+
+#
+@pytest.mark.parametrize("divisor", [2, 10])
+@pytest.mark.parametrize("redemption_price_scale", [0.5, 2])
+@pytest.mark.itercoins("zero_idx")
+def test_exceed_max_burn_imbalanced(alice, swap, wrapped_coins, pool_token, divisor, initial_amounts, base_amount,
+                                    n_coins, redemption_price_scale, redemption_price_snap, zero_idx):
+    
+    amounts = [i // divisor for i in initial_amounts]
+    # imbalanced
+    amounts[zero_idx] = 0
+    redemption_price_snap.setRedemptionPriceSnap(redemption_price_scale * 1e27)
+    if (zero_idx == redemption_index) == (redemption_price_scale == 2):
+        burn_scale = 2 / 3
+    else:
+        burn_scale = 4 / 3
+    max_burn = (burn_scale * (n_coins - 1) * 10 ** 18 * base_amount) // divisor
+
+    # Ensure the max burn moves with the redemption price to reflect the proportion of liquidity value removed
+    with brownie.reverts("Slippage screwed you"):
+        swap.remove_liquidity_imbalance(amounts, max_burn * 0.999, {"from": alice})

--- a/tests/pools/raiust/unitary/test_remove_liquidity_moving_rp_raiust.py
+++ b/tests/pools/raiust/unitary/test_remove_liquidity_moving_rp_raiust.py
@@ -1,0 +1,27 @@
+import pytest
+
+pytestmark = pytest.mark.usefixtures("add_initial_liquidity")
+
+
+@pytest.mark.parametrize("redemption_price_scale", [0.5, 2])
+def test_remove_liquidity(alice, swap, wrapped_coins, pool_token, initial_amounts, base_amount, n_coins,
+                          redemption_price_scale, redemption_price_snap):
+    # For clarity this is the state post setup. Alice has deposited 1MM each of redemption coin and lp token when the
+    # redemption price was 1.
+    assert pool_token.balanceOf(alice) == n_coins * 10 ** 18 * base_amount == pool_token.totalSupply()
+    for coin, amount in zip(wrapped_coins, initial_amounts):
+        assert coin.balanceOf(swap) == 1000000 * 10**18
+
+    # Now modify the redemption price and remove half the liquidity. The received tokens should be independent of the
+    # redemption price, half the LP tokens should give half the underlying tokens.
+    redemption_price_snap.setRedemptionPriceSnap(redemption_price_scale * 1e27)
+    swap.remove_liquidity(
+        n_coins * 10 ** 18 * base_amount / 2, [0, 0], {"from": alice}
+    )
+
+    for coin, amount in zip(wrapped_coins, initial_amounts):
+        assert coin.balanceOf(alice) == amount / 2
+        assert coin.balanceOf(swap) == amount / 2
+
+    assert pool_token.balanceOf(alice) == n_coins * 10 ** 18 * base_amount / 2
+    assert pool_token.totalSupply() == n_coins * 10 ** 18 * base_amount / 2

--- a/tests/pools/raiust/unitary/test_rp_caching_raiust.py
+++ b/tests/pools/raiust/unitary/test_rp_caching_raiust.py
@@ -1,0 +1,20 @@
+import pytest
+
+pytestmark = pytest.mark.usefixtures("add_initial_liquidity")
+
+
+def test_redemption_price(chain, bob, swap, initial_amounts, n_coins, redemption_price_snap):
+    redemption_price = redemption_price_snap.snappedRedemptionPrice()
+
+    chain.sleep(86400)
+    chain.mine()
+
+    assert redemption_price == redemption_price_snap.snappedRedemptionPrice()
+
+    redemption_price += 1e25
+    redemption_price_snap.setRedemptionPriceSnap(redemption_price)
+
+    chain.sleep(86400)
+    chain.mine()
+
+    assert redemption_price == redemption_price_snap.snappedRedemptionPrice()


### PR DESCRIPTION
This pool implementation is to realize two coin pool with a peggie and a non-peggie according to the demand of [Gitcoin bounty](https://gitcoin.co/issue/reflexer-labs/curve-contract/6/100027296) from Reflexer-Labs. To make the implementation more specific, RAI is used as non-peggie coin, and UST is used as peggi coin. You can change to other coins to make a new pool, just to reset the pooldata.json. In order to optimize, the coin should have 18 decimals. I also write specific tests for moving redemption price of RAI. I have run the tests locally. The pool has passed all default common tests and specific tests.  Detailed instruction about the pool can refer to RAIUST_POOL_README.md. 